### PR TITLE
fix config file .env upgrade

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -26,6 +26,16 @@ ynh_script_progression --message="Updating NGINX web server configuration..." --
 ynh_change_url_nginx_config
 
 #=================================================
+# MODIFY CONFIGURATION
+#=================================================
+ynh_script_progression --message="Modifying configuration file..." --weight=1
+
+ynh_add_config --template="env" --destination="$install_dir/.env"
+
+chmod 400 "$install_dir/.env"
+chown "$app:$app" "$install_dir/.env"
+
+#=================================================
 # GENERIC FINALISATION
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -31,6 +31,16 @@ chown -R "$app:$app" "$install_dir"
 chmod +x "$install_dir/nocodb"
 
 #=================================================
+# UPGRADE CONFIGURATION
+#=================================================
+ynh_script_progression --message="Upgrade configuration file..." --weight=1
+
+ynh_add_config --template="env" --destination="$install_dir/.env"
+
+chmod 400 "$install_dir/.env"
+chown "$app:$app" "$install_dir/.env"
+
+#=================================================
 # REAPPLY SYSTEM CONFIGURATIONS
 #=================================================
 ynh_script_progression --message="Upgrading system configurations related to $app..." --weight=1


### PR DESCRIPTION
fix config file .env was not modified not during upgrade neither during change url

## Problem

- I found my nocodb install crashed and with an outdated config file

## Solution

- I saw in code that the template for .env file was updated but the changes were not applied on upgrade and change_url scripts

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested 

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
