### PR TITLE
fix ci bookworm : add deps to redis-server

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -66,6 +66,7 @@ ram.runtime = "50M"
     [resources.apt]
     packages = [
         "mariadb-server",
+        "redis-server"
     ]
 
     [resources.database]


### PR DESCRIPTION


## Problem

- *ci ko on bookworm*

## Solution

- *the app crashes because it cannot connect to its own embedded redis server, test if systemd hardening is the culprit*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
